### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.22.0
+    
+WORKDIR /app
+
+COPY . .
+
+RUN go mod download
+
+RUN go mod tidy
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /parcel
+
+CMD ["/parcel"]


### PR DESCRIPTION
Пробовал добавить источником изображение с тегом [1.22.3-alpine3.20], поскольку открытые источники ссылаются на необходимость интеграции использования sql. Однако, в итоге результат без использования данной интеграции получил такой же при локальном тестировании. Несколько раз пробовал поместить собранный образ в Docker Playground, но так и не осилил разобраться с разной версии платформы. Собирал специально под linux, однако версия виртуальный платформы сильно ниже и подобрать соответствующий исходный образ не удалось. Прошу помощи тут, поскольку не успеваю до отправки задания по дедлайну получить ответ на вопрос в чате своей группы. Так же хотелось бы услышать мнение насчет использования изображений с тегами "...alpine"